### PR TITLE
Add support for dtso files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "languages": [{
             "id": "dts",
             "aliases": ["DeviceTree", "dts"],
-            "extensions": [".dts",".dtsi"],
+            "extensions": [".dts",".dtsi", ".dtso"],
             "configuration": "./language-configuration.json"
         }],
         "grammars": [{


### PR DESCRIPTION
Device tree overlay files use the same syntax.

Signed-off-by: Razvan Stefanescu <stefanescu.razvan@gmail.com>